### PR TITLE
Corrected link to 'new Issue'

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ CDLA-Permissive-1.0
 
 ## Collaborating With the WG
 
-1. Create a [new Issue](https://github.com/Green-Software-Foundation/standards_wg/issues/new)
+1. Create a [new Issue](https://github.com/Green-Software-Foundation/innovation_wg/issues/new)
 2. Discuss Issue with WG --> Create PR if required
 3. PR to be submitted against the **DEV feature branch**
 4. PR discussed with the WG. If agreed, the WG Chair will merge into **DEV Feature branch**


### PR DESCRIPTION
Link 'new issue' pointed to standards wg.